### PR TITLE
More precision on pilfer and relocate_out functions

### DIFF
--- a/relocation.bs
+++ b/relocation.bs
@@ -1857,18 +1857,80 @@ any& any::operator=(T);
 
 ## Containers ## {#lib-change-containers}
 
-All containers should provide a way to insert and remove elements by relocation.
-
-Unfortunately existing APIs cannot fulfill this need. They mostly take references 
-of some kind as parameter, while relocation requires to pass elements by value.
-
-As such we suggest adding overloads to all insertion functions. 
-These shall capture the element to insert by value.
-
-In addition we add various "pilfer" functions to remove elements from containers.
-
-Finally, all containers must provide a relocation constructor and a 
+All containers must provide a relocation constructor and a
 relocation assignment operator.
+
+Also, in order to fully support relocate-only types, containers should provide
+a way to insert and remove elements by relocation.
+
+### Insertion overloads ### {#lib-insertion-overloads}
+
+Existing APIs cannot fulfill this need. They all take the element
+to insert as a reference parameter, while relocation requires to pass elements
+by value.
+
+As such we suggest adding overloads to all insertion functions, where the
+element to insert is passed by value.
+
+### Pilfer functions ### {#lib-pilfer-functions}
+
+The STL does not provide any function to erase an element
+from a container and return it as return value.
+
+Consider a container of relocate-only types. If an element of that container is to be
+"moved out" of it, it could only happen through relocation as it is
+the only operation supported by the type. Hence the relocated element must
+necessarily be simultaneously erased from the container as its lifetime ended.
+
+This is why we propose to add various "pilfer" functions to existing containers,
+that erase an element and return it. The return value will be constructed by
+relocation (likely thanks to `std::destroy_relocate`).
+
+All pilfer functions will operate the same way. First, the return value is constructed
+as if by `std::destroy_relocate` from the container element. Second, the container
+adjusts its size and memory to effectively erase the contained element from
+its internal data structures.
+
+If an exception is emitted during the first step, then the container proceeds
+to erase its element nonetheless (as if in the second step) and then propagates
+the exception.
+If an exception is emitted during the second step
+(regardless of whether the second step was triggered normally of by an exception
+caught the first step), then `std::terminate` is called.
+
+### relocate_out ### {#lib-relocate_out}
+
+We further propose to add a `relocate_out` function to some containers.
+`relocate_out` takes three iterators as parameters. The first two are iterators
+that belong to the container, and define the range to relocate. The last parameter
+is an output iterator where the relocated elements will be constructed.
+This is similar the `erase` functions that take a range of elements, except that
+an extra output iterator is provided.
+
+`relocate_out` is proposed to improve support of relocate-only types. Without this,
+it would not be possible to move a range of relocate-only elements from one container to
+another, without writing complex and inefficient loops calling `pilfer` at
+each iteration.
+
+Note that there is less need for a `relocate_in` function as the `std::insert_iterator`
+family will have an overload to enable relocation.
+
+`relocate_out` proceeds as follows:
+
+1. relocates the elements within range to the output iterator.
+    The elements within range inside the container are then in a *destructed state*.
+2. The destructed elements are removed from the container. How this is achieved
+    depends on the container. For instance `std::vector` may call
+    `std::uninitialized_relocate` to move the trailing part of the container
+    in the destructed range, and simply reduce its size.
+
+If an exception leaks through the first step, then the second step is run
+to erase from the container all the elements that are in a *destructed state*
+(i.e. those which got succesfully relocated plus the one responsible for the exception)
+, and the exception is propagated.
+If an exception is emitted during the second step
+(regardless of whether the second step was triggered normally of by an exception
+caught the first step), then `std::terminate` is called.
 
 ### std::vector ### {#std-vector}
 ```cpp


### PR DESCRIPTION
Detail motivation and exception behavior.

We still need to motivate the name of 'pilfer' vs 'pop', that will wait until the corresponding issue is resolved.